### PR TITLE
case insensitive commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "mongoose": "^5.9.25",
     "nodemon": "^2.0.4",
     "pino": "^6.3.2",
-    "typescript": "^3.9.5"
+    "typescript": "^3.9.7",
+    "yarn": "^1.22.10"
   },
   "devDependencies": {
     "pino-pretty": "^4.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { UserStore } from "./stores/userStore";
 import { ChallengeStore } from "./stores/challengeStore";
 import logger from "./logger";
 
-import { commandParser, givenMoney, errorEvent } from "./util";
+import { commandParser, givenMoney, errorEvent, caseInsensitiveComparator } from "./util";
 
 import { commandsByAlias, prohibitedCommands } from "./commands";
 import express from "express";
@@ -46,14 +46,15 @@ async function Main() {
         const [fullCommand, body] = commandParser(content);
         // check if the command is in the prohibited routes (=\, =/, etc.)
         const cmd = fullCommand.substr(1);
+         // todo lowercase when needed
          if (prohibitedCommands.includes(fullCommand)) {
           // if so, ignore
           return;
         }
 
-       
-        if (commandsByAlias[cmd]) {
-          const command = commandsByAlias[cmd];
+        const key = caseInsensitiveComparator(cmd, commandsByAlias)
+        if (key != "") {
+          const command = commandsByAlias[key];
 
           if (
             command.requiresRole &&

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,6 +15,15 @@ export const roleHandler = (src: string): string[] => {
     : [];
 }; //return array of ids from string;
 
+export const caseInsensitiveComparator(key: string, dict: [String]: any) {
+  for (var k in a) {
+    if (k.toLowerCase() == key.toLowerCase()) {
+      return k;
+    }
+  };
+  return "";
+}
+
 export const emojiHandler = (emojiString: string): string => {
   if (emojiString.startsWith("<")) {
     return emojiString.split(":")[2].replace(">", "");

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,7 @@ export const roleHandler = (src: string): string[] => {
     : [];
 }; //return array of ids from string;
 
-export const caseInsensitiveComparator(key: string, dict: Record<string, any>): string => {
+export const caseInsensitiveComparator = (key: string, dict: Record<string, any>): string => {
   for (var k in a) {
     if (k.toLowerCase() == key.toLowerCase()) {
       return k;

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,7 @@ import {
   DMChannel,
   NewsChannel,
 } from "discord.js";
+import { CommandSystem, Command } from "../types";
 import logger from "./logger";
 
 const roleRegex = /<@&(\d+)>/g;
@@ -15,7 +16,7 @@ export const roleHandler = (src: string): string[] => {
     : [];
 }; //return array of ids from string;
 
-export const caseInsensitiveComparator(key: string, dict: [String]: any): string => {
+export const caseInsensitiveComparator(key: string, dict: Record<string, any>): string => {
   for (var k in a) {
     if (k.toLowerCase() == key.toLowerCase()) {
       return k;

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ export const roleHandler = (src: string): string[] => {
     : [];
 }; //return array of ids from string;
 
-export const caseInsensitiveComparator(key: string, dict: [String]: any) {
+export const caseInsensitiveComparator(key: string, dict: [String]: any): string => {
   for (var k in a) {
     if (k.toLowerCase() == key.toLowerCase()) {
       return k;

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,6 @@ import {
   DMChannel,
   NewsChannel,
 } from "discord.js";
-import { CommandSystem, Command } from "../types";
 import logger from "./logger";
 
 const roleRegex = /<@&(\d+)>/g;
@@ -17,7 +16,7 @@ export const roleHandler = (src: string): string[] => {
 }; //return array of ids from string;
 
 export const caseInsensitiveComparator = (key: string, dict: Record<string, any>): string => {
-  for (var k in a) {
+  for (var k in dict) {
     if (k.toLowerCase() == key.toLowerCase()) {
       return k;
     }


### PR DESCRIPTION
1. Added `caseInsensitiveComparator` in `utils`
2. Added key fetching by `cmd` to `index`
3. Changed `commandsByAlias[cmd]` check to `key != ""`

Any command will now use the first actual command found by lowercase match